### PR TITLE
Fix RTD Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"


### PR DESCRIPTION
Force image to build the documentation because of https://github.com/readthedocs/readthedocs.org/issues/10290